### PR TITLE
Fix winget spell check error in powershell

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -1,0 +1,45 @@
+{
+  "version": "0.2",
+  "language": "en",
+  "words": [
+    "winget",
+    "pwsh",
+    "powershell",
+    "WinGet",
+    "PowerShell",
+    "microsoft",
+    "Microsoft",
+    "admin",
+    "cmdlet",
+    "cmdlets",
+    "param",
+    "params",
+    "env",
+    "foreach",
+    "ErrorActionPreference",
+    "LASTEXITCODE",
+    "WindowsIdentity",
+    "WindowsPrincipal",
+    "WindowsBuiltInRole",
+    "PSVersionTable",
+    "exe",
+    "silentlycontinue",
+    "SilentlyContinue",
+    "programfiles",
+    "ProgramFiles",
+    "machinekey",
+    "userkey",
+    "systempath",
+    "newpath"
+  ],
+  "ignorePaths": [
+    "node_modules/**",
+    ".git/**",
+    "*.min.js",
+    "*.map"
+  ],
+  "ignoreWords": [
+    "LASTEXITCODE",
+    "ErrorActionPreference"
+  ]
+}


### PR DESCRIPTION
Add `cspell.json` to resolve 'winget' unknown word error and prevent future PowerShell/Windows-related false positives.

The cSpell linter flagged 'winget' as an unknown word, which is a legitimate Microsoft tool. This PR adds a `cspell.json` configuration file to the project, including 'winget' and other common PowerShell cmdlets, variables, and Windows-specific terms to improve spell-checking accuracy and reduce false positives.

---
<a href="https://cursor.com/background-agent?bcId=bc-63d849b1-2150-4518-9eb3-4ad590465a96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-63d849b1-2150-4518-9eb3-4ad590465a96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

